### PR TITLE
Fixing typo in S06P05

### DIFF
--- a/problem-sets/set06.tex
+++ b/problem-sets/set06.tex
@@ -47,7 +47,7 @@ product on cohomology.
 
 \begin{problem}\label{no-retraction}The $n$-disk $D^n$ has the $(n-1)$-sphere as its
 boundary; write $i : S^{n-1} \to D^n$ for the inclusion map.  We say
-that $r : S^{n-1} \to D^n$ is a \textbf{retraction} if $r \circ i =
+that $r : D^n \to S^{n-1}$ is a \textbf{retraction} if $r \circ i =
 \id_{\partial D^n}$.
 
 Can you find a retraction of the disk onto its boundary?


### PR DESCRIPTION
In Problem 5, you want the retraction to go in the opposite direction of the inclusion and so I believe you flipped the domain and codomian of r in the statement.